### PR TITLE
fixed default param

### DIFF
--- a/opencanary_correlator/common/notifications.py
+++ b/opencanary_correlator/common/notifications.py
@@ -22,7 +22,7 @@ def notify(incident):
     if c.config.getVal('console.email_notification_enable', False):
         logger.debug('Email notifications enabled')
         addresses = c.config.getVal('console.email_notification_address', default=[])
-        if c.config.getVal('console.mandrill_key', default=''):
+        if c.config.getVal('console.mandrill_key', False):
             for address in addresses:
                 logger.debug('Email sent to %s' % address)
                 mandrill_send(to=address,


### PR DESCRIPTION
Initially the if statement wasn't working when I first installed the correlator, then I deleted the whole statement and the case when the mandrill key was found and everything worked fine.
Now I tried to change the default value to False and recompiled it from source, everything still works fine.
p.s. shouldn't the host and port parameters be included in the config file by default? I found out that they existed only by reading the source code since they aren't documented anywhere :)
