### PR TITLE
Minor syntax edits and one alert

### DIFF
--- a/opencanary_correlator/common/config.py
+++ b/opencanary_correlator/common/config.py
@@ -65,7 +65,7 @@ class Config:
                 json.dump(self.__config, f)
 
         except Exception, e:
-            print "[-] Failed to save config file %s" % e
+            print("[-] Failed to save config file %s" % e)
             raise ConfigException("config", e)
 
     def __repr__(self):

--- a/opencanary_correlator/common/emailer.py
+++ b/opencanary_correlator/common/emailer.py
@@ -40,7 +40,8 @@ def mandrill_send(to=None, subject=None, message=None, reply_to=None):
         if reply_to:
             message["headers"] = { "Reply-To": reply_to }
 
-        # With Python 3.x this line will fail because async is a reserved word
+        # With Python 3.7 this line will fail because async is a reserved word
+        # The new line should be: result = mandrill_client.messages.send(message=message, asy=False, ip_pool='Main Pool')
         result = mandrill_client.messages.send(message=message, async=False, ip_pool='Main Pool')
 
     except mandrill.Error, e:

--- a/opencanary_correlator/common/emailer.py
+++ b/opencanary_correlator/common/emailer.py
@@ -43,4 +43,4 @@ def mandrill_send(to=None, subject=None, message=None, reply_to=None):
         result = mandrill_client.messages.send(message=message, async=False, ip_pool='Main Pool')
 
     except mandrill.Error, e:
-        print 'A mandrill error occurred: %s - %s' % (e.__class__, e)
+        print('A mandrill error occurred: %s - %s' % (e.__class__, e))

--- a/opencanary_correlator/common/emailer.py
+++ b/opencanary_correlator/common/emailer.py
@@ -40,6 +40,7 @@ def mandrill_send(to=None, subject=None, message=None, reply_to=None):
         if reply_to:
             message["headers"] = { "Reply-To": reply_to }
 
+        # With Python 3.x this line will fail because async is a reserved word
         result = mandrill_client.messages.send(message=message, async=False, ip_pool='Main Pool')
 
     except mandrill.Error, e:

--- a/opencanary_correlator/common/incidents.py
+++ b/opencanary_correlator/common/incidents.py
@@ -392,7 +392,7 @@ class IncidentFactory:
 
     @classmethod
     def create_incident(cls, type_, data=None):
-        print '{0}: {1}'.format(type_, data)
+        print('{0}: {1}'.format(type_, data))
         logger.debug('Creating incident type: {0}'.format(type_))
         if type_ == 'ftp.login_attempt':
             IncidentFTPLogin(data=data, write_object=True)

--- a/opencanary_correlator/common/logs.py
+++ b/opencanary_correlator/common/logs.py
@@ -25,6 +25,10 @@ logger = None
 # Console and correlator use different logger names. Common modules
 # should still log to the logger for the process under which they're running.
 # Impact of this is we don't support multiple loggers per process
+
+# In Python 3.x this will fail as dict_keys() is no longer returns a list, but an object.
+# The following will provide an iterable list (if that is still the right thing to do)
+# existing_logger_names = list(logging.getLogger().manager.loggerDict.keys())
 existing_logger_names = logging.getLogger().manager.loggerDict.keys()
 if len(existing_logger_names) > 0:
     lgr = existing_logger_names[0]

--- a/opencanary_correlator/common/queries.py
+++ b/opencanary_correlator/common/queries.py
@@ -142,6 +142,6 @@ def set_console_setting(setting, value):
     return redis.set(key, value)
 
 if __name__ == "__main__":
-    print 'All: %r'  % get_all_devices()
-    print 'All Incidents: %r' % get_all_incidents()
-    print 'All Unacknowledged Incidents: %r' % get_unacknowledged_incidents()
+    print('All: %r'  % get_all_devices())
+    print('All Incidents: %r' % get_all_incidents())
+    print('All Unacknowledged Incidents: %r' % get_unacknowledged_incidents())

--- a/opencanary_correlator/receiver.py
+++ b/opencanary_correlator/receiver.py
@@ -26,7 +26,7 @@ class CorrelatorReceiver(LineReceiver):
             event = json.loads(line)
         except Exception as e:
             print >> sys.stderr, "Failed to decode line"
-            print e
+            print(e)
             return
 
         process_device_report(event)
@@ -42,9 +42,9 @@ def main():
     try:
         config = CorrelatorOptions()
         config.parseOptions()
-    except usage.UsageError, ue:
+    except usage.UsageError as ue:
         print >> sys.stderr, '%s:' % sys.argv[0], ue
-        print config
+        print(config)
         sys.exit(1)
 
     common.config.config = common.config.Config(config.opts['config'])


### PR DESCRIPTION
Just some minor syntax changes for things that will break under Python 3.x, specifically

- "except foo, f" to "except foo as f"
- "print foo" to "print(foo)"

Also commented above the mandrill_send line in emailer.py as async is a reserved word, so this will not work.

Here's to hoping we can get correlator working in a modern version of Python!